### PR TITLE
Fix `@grant none` disables all other `@grant` keys error

### DIFF
--- a/mydramalist-native-titles.user.js
+++ b/mydramalist-native-titles.user.js
@@ -1,7 +1,6 @@
 // ==UserScript==
 // @name        MyDramaList Native Titles
 // @match       https://mydramalist.com/*
-// @grant       none
 // @version     1.4.2
 // @namespace   https://github.com/MarvNC
 // @author      Marv


### PR DESCRIPTION
The latest version of ViolentMonkey disables scripts with `@grant none` and throws the error "`@grant none` disables all other `@grant` keys".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated script permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->